### PR TITLE
[DB-01] Setup necessary classes for database interaction.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("org.springframework.boot") version "3.3.0"
-    id("io.spring.dependency-management") version "1.1.5"
+    id("org.springframework.boot") version "3.5.3"
+    id("io.spring.dependency-management") version "1.1.7"
     id("java")
 }
 
@@ -15,12 +15,6 @@ repositories {
     mavenCentral()
 }
 
-dependencyManagement {
-    imports {
-        mavenBom("software.amazon.awssdk:bom:2.25.41")
-    }
-}
-
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -28,8 +22,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-datadog")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui")
     implementation("software.amazon.awssdk:s3")
+    "developmentOnly"("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/src/main/java/org/ddamme/database/model/FileMetadata.java
+++ b/src/main/java/org/ddamme/database/model/FileMetadata.java
@@ -1,0 +1,44 @@
+package org.ddamme.database.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "file_metadata")
+public class FileMetadata {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String originalFilename;
+
+    @Column(nullable = false, unique = true)
+    private String storageKey;
+
+    @Column(nullable = false)
+    private long size;
+
+    @Column(nullable = false)
+    private String contentType;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant uploadTimestamp;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private Instant updateTimestamp;
+} 

--- a/src/main/java/org/ddamme/database/repository/MetadataRepository.java
+++ b/src/main/java/org/ddamme/database/repository/MetadataRepository.java
@@ -1,0 +1,9 @@
+package org.ddamme.database.repository;
+
+import org.ddamme.database.model.FileMetadata;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MetadataRepository extends JpaRepository<FileMetadata, Long> {
+} 

--- a/src/main/java/org/ddamme/service/MetadataService.java
+++ b/src/main/java/org/ddamme/service/MetadataService.java
@@ -1,0 +1,31 @@
+package org.ddamme.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ddamme.database.model.FileMetadata;
+import org.ddamme.database.repository.MetadataRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MetadataService {
+
+    private final MetadataRepository metadataRepository;
+
+    @Transactional
+    public FileMetadata save(FileMetadata metadata) {
+        return metadataRepository.save(metadata);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FileMetadata> findById(Long id) {
+        return metadataRepository.findById(id);
+    }
+
+    @Transactional
+    public void deleteById(Long id) {
+        metadataRepository.deleteById(id);
+    }
+} 


### PR DESCRIPTION
This PR sets up the core persistence layer for managing file metadata.

*   **JPA Entity:** Added `FileMetadata` to define the schema for our `file_metadata` table, including fields like `storageKey`, `size`, and auto-managed timestamps.
*   **Repository & Service:** Implemented a Spring Data `MetadataRepository` for database operations and a transactional `MetadataService` to house business logic.
*   **Housekeeping:** Updated dependencies to Spring Boot `3.5.3` and refactored persistence components into a new `database` package for better organization.