### PR TITLE
[DB-02] Got db running in docker, changed up some config to run program.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-datadog")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
     implementation("software.amazon.awssdk:s3")
     "developmentOnly"("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")
@@ -31,6 +31,16 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("software.amazon.awssdk:bom:2.31.72")
+    }
+}
+
 tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.withType<Test> {
     useJUnitPlatform()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  postgres-db:
+    image: postgres:17-alpine
+    container_name: file-system-postgres
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=file_system_db
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:
+    driver: local 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,13 +13,9 @@ spring:
   config:
     activate:
       on-profile: dev
-  # Server port for the application
-  web:
-    server:
-      port: 8080
   # Database connection settings for PostgreSQL
   datasource:
-    url: jdbc:postgresql://localhost:5432/file-metadata-db
+    url: jdbc:postgresql://localhost:5433/file_system_db
     username: user
     password: password
     driver-class-name: org.postgresql.Driver
@@ -32,6 +28,17 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+
+# Server port for the application
+server:
+  port: 8080
+
+# Management endpoints and metrics settings
+management:
+  datadog:
+    metrics:
+      export:
+        enabled: false # Disable sending metrics to Datadog for local development
 
 # --- Production Profile (prod) - Placeholder ---
 ---


### PR DESCRIPTION
This PR completes the database module setup by introducing Docker for a consistent local development environment and connecting our Spring Boot application to it.

*   **Docker Compose:** Added a `docker-compose.yml` to run a PostgreSQL 17 database in a container. This makes setup for any developer a single `docker compose up` command.
*   **Application Configuration:**
    *   Configured the `dev` profile in `application.yml` to connect to the Dockerized database.
    *   Set `jpa.hibernate.ddl-auto: update` so Hibernate automatically creates/updates our database schema on startup, which makes migrations seamless during development.
*   **Housekeeping & Fixes:**
    *   Resolved dependency conflicts by setting explicit versions for the AWS SDK BOM and SpringDoc.
    *   Disabled the Datadog metrics exporter in the `dev` profile to prevent startup errors when an API key isn't present.

With this, the entire persistence layer is now fully configured and functional for local development.