### PR TITLE
[API-01] Added REST API for files in FileController.

### DIFF
--- a/src/main/java/org/ddamme/controller/FileController.java
+++ b/src/main/java/org/ddamme/controller/FileController.java
@@ -1,0 +1,80 @@
+package org.ddamme.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ddamme.database.model.FileMetadata;
+import org.ddamme.service.MetadataService;
+import org.ddamme.service.StorageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final MetadataService metadataService;
+    private final StorageService storageService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<?> uploadFile(@RequestParam("file") MultipartFile file) {
+        // 1. Upload the file to storage and get the storage key
+        String storageKey = storageService.upload(file);
+        
+        // 2. Create metadata record
+        FileMetadata metadata = FileMetadata.builder()
+                .originalFilename(file.getOriginalFilename())
+                .storageKey(storageKey)
+                .size(file.getSize())
+                .contentType(file.getContentType())
+                .build();
+        
+        // 3. Save metadata to database
+        FileMetadata savedMetadata = metadataService.save(metadata);
+        
+        // 4. Return the saved metadata
+        return ResponseEntity.ok(savedMetadata);
+    }
+
+    @GetMapping("/download/{id}")
+    public ResponseEntity<?> downloadFile(@PathVariable Long id) {
+        // 1. Get metadata from database
+        Optional<FileMetadata> metadataOptional = metadataService.findById(id);
+        
+        if (metadataOptional.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        
+        FileMetadata metadata = metadataOptional.get();
+        
+        // 2. Generate presigned download URL
+        String downloadUrl = storageService.generatePresignedDownloadUrl(metadata.getStorageKey());
+        
+        // 3. Return the URL
+        return ResponseEntity.ok(Map.of("downloadUrl", downloadUrl));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteFile(@PathVariable Long id) {
+        // 1. Get metadata from database
+        Optional<FileMetadata> metadataOptional = metadataService.findById(id);
+        
+        if (metadataOptional.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        
+        FileMetadata metadata = metadataOptional.get();
+        
+        // 2. Delete file from storage
+        storageService.delete(metadata.getStorageKey());
+        
+        // 3. Delete metadata record from database
+        metadataService.deleteById(id);
+        
+        // 4. Return 204 No Content
+        return ResponseEntity.noContent().build();
+    }
+} 


### PR DESCRIPTION
This PR adds the `FileController` to expose our file management logic via a REST API. It allows clients to upload, download, and delete files.

**Key Changes:**

*   **Created `FileController` under the `/files` base path.**
*   **`POST /upload`**: Handles file uploads, saves the file to S3, and creates a corresponding metadata record in the database.
*   **`GET /download/{id}`**: Retrieves metadata and returns a secure, time-limited presigned URL for downloading the file.
*   **`DELETE /id`**: Deletes the file from S3 and removes its metadata record from the database.
*   **Error Handling**: Returns `404 Not Found` for invalid IDs.