### PR TITLE
[TEST-03] Tiered integration tests: fast app ITs, LocalStack S3, and full end-to-end file flow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:localstack")
 }
 
 dependencyManagement {

--- a/src/integrationTest/java/org/ddamme/controller/AuthControllerIT.java
+++ b/src/integrationTest/java/org/ddamme/controller/AuthControllerIT.java
@@ -2,6 +2,7 @@ package org.ddamme.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.ddamme.dto.RegisterRequest;
+import org.ddamme.dto.LoginRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,13 +10,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.ddamme.testsupport.BaseIntegrationTest;
+import org.ddamme.dto.LoginRequest;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class AuthControllerIT extends BaseIntegrationTest {
 
     @Autowired
@@ -37,6 +42,56 @@ class AuthControllerIT extends BaseIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(payload)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /register successfully creates a new user")
+    void register_success() throws Exception {
+        String uniqueUser = "ituser-register-" + System.currentTimeMillis();
+        RegisterRequest register = RegisterRequest.builder()
+                .username(uniqueUser)
+                .email(uniqueUser + "@example.com")
+                .password("a-valid-password-123")
+                .build();
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(register)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isString())
+                .andExpect(jsonPath("$.username").value(uniqueUser));
+    }
+
+    @Test
+    @DisplayName("login succeeds and returns token")
+    void login_success_returnsToken() throws Exception {
+        String uniqueUser = "ituser-login-" + System.currentTimeMillis();
+        String email = uniqueUser + "@example.com";
+
+        // Register user first
+        RegisterRequest register = RegisterRequest.builder()
+                .username(uniqueUser)
+                .email(email)
+                .password("secret123")
+                .build();
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(register)))
+                .andExpect(status().isOk());
+
+        // Then login
+        LoginRequest login = LoginRequest.builder()
+                .username(uniqueUser)
+                .password("secret123")
+                .build();
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isString())
+                .andExpect(jsonPath("$.username").value(uniqueUser))
+                .andExpect(jsonPath("$.role").isString());
     }
 }
 

--- a/src/integrationTest/java/org/ddamme/controller/AuthControllerIT.java
+++ b/src/integrationTest/java/org/ddamme/controller/AuthControllerIT.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.ddamme.testsupport.BaseIntegrationTest;
-import org.ddamme.dto.LoginRequest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.annotation.DirtiesContext;
 

--- a/src/integrationTest/java/org/ddamme/controller/FileAuthorizationIT.java
+++ b/src/integrationTest/java/org/ddamme/controller/FileAuthorizationIT.java
@@ -1,0 +1,108 @@
+package org.ddamme.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import java.time.Instant;
+import org.ddamme.database.model.FileMetadata;
+import org.ddamme.database.model.User;
+import org.ddamme.database.repository.MetadataRepository;
+import org.ddamme.database.repository.UserRepository;
+import org.ddamme.dto.LoginRequest;
+import org.ddamme.dto.RegisterRequest;
+import org.ddamme.testsupport.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FileAuthorizationIT extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MetadataRepository metadataRepository;
+
+    @Test
+    @DisplayName("Accessing another user's file returns 403")
+    void crossUser_access_forbidden() throws Exception {
+        // Register owner (A)
+        String userA = "owner" + System.currentTimeMillis();
+        RegisterRequest regA = RegisterRequest.builder()
+                .username(userA)
+                .email(userA + "@example.com")
+                .password("secret123")
+                .build();
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(regA)))
+                .andExpect(status().isOk());
+
+        // Load owner entity
+        User owner = userRepository.findByUsername(userA).orElseThrow();
+
+        // Create a file metadata owned by A
+        FileMetadata fm = FileMetadata.builder()
+                .originalFilename("doc.txt")
+                .storageKey("s3/key/" + System.nanoTime())
+                .size(10L)
+                .contentType("text/plain")
+                .uploadTimestamp(Instant.now())
+                .user(owner)
+                .build();
+        fm = metadataRepository.save(fm);
+
+        // Register attacker (B)
+        String userB = "attacker" + System.currentTimeMillis();
+        RegisterRequest regB = RegisterRequest.builder()
+                .username(userB)
+                .email(userB + "@example.com")
+                .password("secret123")
+                .build();
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(regB)))
+                .andExpect(status().isOk());
+
+        // Login as B
+        LoginRequest loginB = LoginRequest.builder()
+                .username(userB)
+                .password("secret123")
+                .build();
+        MvcResult loginRes = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginB)))
+                .andExpect(status().isOk())
+                .andReturn();
+        String tokenB = JsonPath.read(loginRes.getResponse().getContentAsString(), "$.token");
+
+        // B attempts to download A's file -> 403
+        mockMvc.perform(get("/files/download/" + fm.getId())
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isForbidden());
+
+        // B attempts to delete A's file -> 403
+        mockMvc.perform(delete("/files/" + fm.getId())
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isForbidden());
+    }
+}
+
+

--- a/src/integrationTest/java/org/ddamme/controller/FileControllerIT.java
+++ b/src/integrationTest/java/org/ddamme/controller/FileControllerIT.java
@@ -18,11 +18,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MvcResult;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class FileControllerIT extends BaseIntegrationTest {
 
     @Autowired

--- a/src/integrationTest/java/org/ddamme/controller/FileControllerIT.java
+++ b/src/integrationTest/java/org/ddamme/controller/FileControllerIT.java
@@ -1,0 +1,95 @@
+package org.ddamme.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.ddamme.dto.LoginRequest;
+import org.ddamme.dto.RegisterRequest;
+import org.ddamme.testsupport.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FileControllerIT extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("/files is 401 without JWT")
+    void files_requiresAuth() throws Exception {
+        mockMvc.perform(get("/files")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("/files/upload requires multipart and auth (401)")
+    void upload_requiresAuth() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "hello.txt", MediaType.TEXT_PLAIN_VALUE, "hi".getBytes());
+        mockMvc.perform(multipart("/files/upload").file(file))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("/files/download/{id} is 401 without JWT")
+    void download_requiresAuth() throws Exception {
+        mockMvc.perform(get("/files/download/1")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("/files/{id} delete is 401 without JWT")
+    void delete_requiresAuth() throws Exception {
+        mockMvc.perform(delete("/files/1")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Authorized GET /files returns 200 with valid JWT")
+    void files_withJwt_listOk() throws Exception {
+        // 1) Register a unique user
+        String username = "itfile" + System.currentTimeMillis();
+        String email = username + "@example.com";
+        RegisterRequest register = RegisterRequest.builder()
+                .username(username)
+                .email(email)
+                .password("secret123")
+                .build();
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(register)))
+                .andExpect(status().isOk());
+
+        // 2) Login to obtain token
+        LoginRequest login = LoginRequest.builder()
+                .username(username)
+                .password("secret123")
+                .build();
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String token = JsonPath.read(loginResult.getResponse().getContentAsString(), "$.token");
+
+        // 3) Authorized GET /files
+        mockMvc.perform(get("/files").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+}
+
+

--- a/src/integrationTest/java/org/ddamme/controller/FileControllerS3IT.java
+++ b/src/integrationTest/java/org/ddamme/controller/FileControllerS3IT.java
@@ -1,0 +1,152 @@
+package org.ddamme.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import java.net.URI;
+import java.time.Duration;
+import org.ddamme.dto.LoginRequest;
+import org.ddamme.dto.RegisterRequest;
+import org.ddamme.testsupport.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Testcontainers
+@Import(FileControllerS3IT.LocalStackS3Config.class)
+class FileControllerS3IT extends BaseIntegrationTest {
+
+    private static final DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:3.6");
+
+    @Container
+    static final LocalStackContainer LOCALSTACK = new LocalStackContainer(LOCALSTACK_IMAGE)
+            .withServices(LocalStackContainer.Service.S3);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private S3Client s3Client;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    @Test
+    @DisplayName("Full flow: Register -> Login -> Upload -> Presign -> Delete (S3 + DB)")
+    void fullFlow_withLocalStack() throws Exception {
+        // Register user
+        String user = "its3user" + System.currentTimeMillis();
+        RegisterRequest reg = RegisterRequest.builder()
+                .username(user)
+                .email(user + "@example.com")
+                .password("secret123")
+                .build();
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reg)))
+                .andExpect(status().isOk());
+
+        // Login
+        LoginRequest login = LoginRequest.builder().username(user).password("secret123").build();
+        MvcResult loginRes = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isString())
+                .andReturn();
+        String token = JsonPath.read(loginRes.getResponse().getContentAsString(), "$.token");
+
+        // Ensure bucket exists
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+
+        // Upload
+        MockMultipartFile file = new MockMultipartFile("file", "hello.txt", MediaType.TEXT_PLAIN_VALUE, "hi".getBytes());
+        MvcResult uploadRes = mockMvc.perform(multipart("/files/upload")
+                        .file(file)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String uploadBody = uploadRes.getResponse().getContentAsString();
+        System.out.println("Upload response: " + uploadBody);
+
+        // Verify via list side-effect
+        MvcResult listRes = mockMvc.perform(get("/files").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.files").exists())
+                .andExpect(jsonPath("$.files.length()").value(1))
+                .andExpect(jsonPath("$.files[0].originalFilename").value("hello.txt"))
+                .andReturn();
+
+        Number idAsNumber = JsonPath.read(listRes.getResponse().getContentAsString(), "$.files[0].id");
+        Long id = idAsNumber.longValue();
+
+        // Presign
+        mockMvc.perform(get("/files/download/" + id)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.downloadUrl").isString());
+
+        // Delete
+        mockMvc.perform(delete("/files/" + id)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+    }
+
+    static class LocalStackS3Config {
+        @Bean
+        @Primary
+        S3Client s3ClientOverride() {
+            return S3Client.builder()
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                    .region(Region.of(LOCALSTACK.getRegion()))
+                    .endpointOverride(URI.create(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+                    .build();
+        }
+
+        @Bean
+        @Primary
+        S3Presigner s3PresignerOverride() {
+            return S3Presigner.builder()
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                    .region(Region.of(LOCALSTACK.getRegion()))
+                    .endpointOverride(URI.create(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+                    .build();
+        }
+    }
+}
+
+

--- a/src/integrationTest/java/org/ddamme/controller/FileControllerS3IT.java
+++ b/src/integrationTest/java/org/ddamme/controller/FileControllerS3IT.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;

--- a/src/integrationTest/java/org/ddamme/controller/FileControllerS3IT.java
+++ b/src/integrationTest/java/org/ddamme/controller/FileControllerS3IT.java
@@ -101,7 +101,6 @@ class FileControllerS3IT extends BaseIntegrationTest {
                 .andReturn();
 
         String uploadBody = uploadRes.getResponse().getContentAsString();
-        System.out.println("Upload response: " + uploadBody);
 
         // Verify via list side-effect
         MvcResult listRes = mockMvc.perform(get("/files").header("Authorization", "Bearer " + token))
@@ -126,6 +125,7 @@ class FileControllerS3IT extends BaseIntegrationTest {
                 .andExpect(status().isNoContent());
     }
 
+    @Configuration
     static class LocalStackS3Config {
         @Bean
         @Primary

--- a/src/integrationTest/java/org/ddamme/security/SecurityEndpointsIT.java
+++ b/src/integrationTest/java/org/ddamme/security/SecurityEndpointsIT.java
@@ -1,0 +1,52 @@
+package org.ddamme.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.ddamme.testsupport.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityEndpointsIT extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Health endpoint is public")
+    void health_isPublic() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("OpenAPI docs are public")
+    void apiDocs_isPublic() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Swagger UI is public")
+    void swagger_isPublic() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Protected routes require auth (401)")
+    void protectedRoutes_requireAuth() throws Exception {
+        mockMvc.perform(get("/files")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/files/download/1")).andExpect(status().isUnauthorized());
+        mockMvc.perform(delete("/files/1")).andExpect(status().isUnauthorized());
+    }
+}
+
+

--- a/src/integrationTest/java/org/ddamme/storage/S3StorageServiceIT.java
+++ b/src/integrationTest/java/org/ddamme/storage/S3StorageServiceIT.java
@@ -1,0 +1,112 @@
+package org.ddamme.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Testcontainers
+@Import(S3StorageServiceIT.LocalStackS3TestConfig.class)
+class S3StorageServiceIT {
+
+    private static final DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:3.6");
+
+    @Container
+    static final LocalStackContainer LOCALSTACK = new LocalStackContainer(LOCALSTACK_IMAGE)
+            .withServices(LocalStackContainer.Service.S3);
+
+    @DynamicPropertySource
+    static void registerS3Properties(DynamicPropertyRegistry registry) {
+        registry.add("aws.s3.bucket-name", () -> "it-bucket");
+    }
+
+    @Autowired
+    private S3Client s3Client;
+
+    @Autowired
+    private S3Presigner s3Presigner;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    @BeforeEach
+    void setupBucket() {
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+    }
+
+    @Test
+    @DisplayName("S3 put -> presign -> get -> delete works against LocalStack")
+    void s3Lifecycle_works() {
+        String key = "it-" + UUID.randomUUID();
+
+        s3Client.putObject(PutObjectRequest.builder().bucket(bucketName).key(key).contentType("text/plain").build(),
+                RequestBody.fromString("hello"));
+
+        PresignedGetObjectRequest presigned = s3Presigner.presignGetObject(
+                GetObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofMinutes(5))
+                        .getObjectRequest(GetObjectRequest.builder().bucket(bucketName).key(key).build())
+                        .build()
+        );
+        assertThat(presigned.url().toString()).contains(key);
+
+        s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(key).build());
+    }
+
+    @Configuration
+    static class LocalStackS3TestConfig {
+        @Bean
+        @Primary
+        S3Client s3ClientOverride() {
+            return S3Client.builder()
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                    .region(Region.of(LOCALSTACK.getRegion()))
+                    .endpointOverride(URI.create(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+                    .build();
+        }
+
+        @Bean
+        @Primary
+        S3Presigner s3PresignerOverride() {
+            return S3Presigner.builder()
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                    .region(Region.of(LOCALSTACK.getRegion()))
+                    .endpointOverride(URI.create(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+                    .build();
+        }
+    }
+}
+
+

--- a/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
+++ b/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
@@ -27,6 +27,8 @@ public abstract class BaseIntegrationTest {
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
         registry.add("security.jwt.secret", () -> "MDEyMzQ1Njc4OWFiY2RlZmdoaWprbG1uMDEyMzQ1Njc4OWFiY2RlZg==");
         registry.add("aws.s3.bucket-name", () -> "test-bucket");
+        registry.add("management.health.db.enabled", () -> "false");
+        registry.add("spring.datasource.hikari.maximumPoolSize", () -> "1");
         registry.add("spring.datasource.hikari.maxLifetime", () -> HIKARI_MAX_LIFETIME_FOR_TESTS);
         registry.add("spring.jpa.show-sql", () -> "false");
     }

--- a/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
+++ b/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
@@ -30,6 +30,7 @@ public abstract class BaseIntegrationTest {
         registry.add("management.health.db.enabled", () -> "false");
         registry.add("spring.datasource.hikari.maximumPoolSize", () -> "1");
         registry.add("spring.datasource.hikari.maxLifetime", () -> HIKARI_MAX_LIFETIME_FOR_TESTS);
+        registry.add("spring.jpa.open-in-view", () -> "true");
         registry.add("spring.jpa.show-sql", () -> "false");
     }
 }

--- a/src/integrationTest/java/org/ddamme/testsupport/LocalStackS3TestConfig.java
+++ b/src/integrationTest/java/org/ddamme/testsupport/LocalStackS3TestConfig.java
@@ -1,0 +1,49 @@
+package org.ddamme.testsupport;
+
+import java.net.URI;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@TestConfiguration
+public class LocalStackS3TestConfig {
+
+    @Container
+    public static final LocalStackContainer LOCALSTACK = new LocalStackContainer(
+            DockerImageName.parse("localstack/localstack:3.6")
+    ).withServices(LocalStackContainer.Service.S3);
+
+    static {
+        LOCALSTACK.start();
+    }
+
+    @Bean
+    @Primary
+    public S3Client s3ClientOverride() {
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                .region(Region.of(LOCALSTACK.getRegion()))
+                .endpointOverride(URI.create(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+                .build();
+    }
+
+    @Bean
+    @Primary
+    public S3Presigner s3PresignerOverride() {
+        return S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                .region(Region.of(LOCALSTACK.getRegion()))
+                .endpointOverride(URI.create(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+                .build();
+    }
+}
+
+

--- a/src/integrationTest/java/org/ddamme/testsupport/TestStorageConfig.java
+++ b/src/integrationTest/java/org/ddamme/testsupport/TestStorageConfig.java
@@ -1,0 +1,47 @@
+package org.ddamme.testsupport;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.ddamme.exception.StorageOperationException;
+import org.ddamme.service.StorageService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.multipart.MultipartFile;
+
+@TestConfiguration
+public class TestStorageConfig {
+
+    @Bean
+    @Primary
+    public StorageService testStorageService() {
+        return new InMemoryStorageService();
+    }
+
+    static class InMemoryStorageService implements StorageService {
+        private final Set<String> keys = ConcurrentHashMap.newKeySet();
+
+        @Override
+        public String upload(MultipartFile file) {
+            String key = UUID.randomUUID().toString() + "-" + (file.getOriginalFilename() == null ? "file" : file.getOriginalFilename());
+            keys.add(key);
+            return key;
+        }
+
+        @Override
+        public String generatePresignedDownloadUrl(String storageKey) {
+            if (!keys.contains(storageKey)) {
+                throw new StorageOperationException("Unknown storage key: " + storageKey);
+            }
+            return "http://localhost/fake/" + storageKey;
+        }
+
+        @Override
+        public void delete(String storageKey) {
+            keys.remove(storageKey);
+        }
+    }
+}
+
+

--- a/src/main/java/org/ddamme/config/AwsConfig.java
+++ b/src/main/java/org/ddamme/config/AwsConfig.java
@@ -2,11 +2,13 @@ package org.ddamme.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
+@Profile("!it-localstack")
 public class AwsConfig {
 
     @Bean


### PR DESCRIPTION
- Summary
  - Implement a robust, tiered testing strategy:
    - Fast app-level ITs with in-memory `StorageService`
    - S3 integration IT with LocalStack for SDK correctness
    - Full end-to-end FileController IT (DB + S3 + security)

- Changes Made
  - Base test stability (Postgres Testcontainer):
    - Disable DB health contributor
    - Tune Hikari pool (size=1, lower lifetime)
    - Enable JPA open-in-view
  - App-level ITs:
    - `AuthControllerIT`: split register/login, DTO + ObjectMapper, isolated with `@DirtiesContext`
    - `FileControllerIT`: Register → Login → GET /files (200) using in-memory `StorageService`
    - `SecurityEndpointsIT`: verify public endpoints and 401 on protected routes
  - S3 tests:
    - `S3StorageServiceIT`: standalone LocalStack S3, explicit `S3Client`/`S3Presigner` beans
    - `FileControllerS3IT`: Register → Login → Upload → List → Presign → Delete; imports `LocalStackS3TestConfig`, uses profile `it-localstack`, and fixes response parsing

- Testing
  - Run: `./gradlew clean test integrationTest`
  - Testcontainers auto-starts Postgres and LocalStack where needed
  - All tests pass

- Checklist
  - [x] Code reviewed by author
  - [x] Tests added/updated
  - [x] No breaking changes
  - [x] Ready for review