### PR TITLE
[DB-02] Adopt Flyway with initial schema and enable migrations in integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 PROJECT_PLAN.md
+.env
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # File System Service
 
-[![CI](https://github.com/ddamme05/File-System/actions/workflows/ci.yml/badge.svg)](https://github.com/ddamme05/File-System/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/ddamme05/File-System/ci.yml?branch=main&label=CI)](https://github.com/ddamme05/File-System/actions/workflows/ci.yml)
 [![Architecture](https://img.shields.io/badge/docs-architecture-blue)](architecture.md)
 [![API Docs](https://img.shields.io/badge/docs-API%20Docs-blue)](docs/api.md)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
     implementation("io.micrometer:micrometer-registry-datadog")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
     implementation("software.amazon.awssdk:s3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
 dependencyManagement {
     imports {
         mavenBom("software.amazon.awssdk:bom:2.31.72")
-        // Align Testcontainers modules
         mavenBom("org.testcontainers:testcontainers-bom:1.20.2")
     }
 }
@@ -62,10 +61,7 @@ tasks.withType<Test> {
 // Integration test source set
 sourceSets {
     create("integrationTest") {
-        java.srcDir("src/integrationTest/java")
-        resources.srcDir("src/integrationTest/resources")
         compileClasspath += sourceSets["main"].output
-        // Also include test outputs so we can reuse test support classes like TestMocksConfig
         compileClasspath += sourceSets["test"].output
         compileClasspath += configurations["testRuntimeClasspath"]
         runtimeClasspath += output

--- a/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
+++ b/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
@@ -24,7 +24,6 @@ public abstract class BaseIntegrationTest {
 
     @DynamicPropertySource
     static void registerDynamicProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
         registry.add("security.jwt.secret", () -> "MDEyMzQ1Njc4OWFiY2RlZmdoaWprbG1uMDEyMzQ1Njc4OWFiY2RlZg==");
         registry.add("aws.s3.bucket-name", () -> "test-bucket");
         registry.add("management.health.db.enabled", () -> "false");

--- a/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
+++ b/src/integrationTest/java/org/ddamme/testsupport/BaseIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.ddamme.testsupport;
 
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.junit.jupiter.Container;
@@ -8,6 +9,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@ActiveProfiles("integrationTest")
 public abstract class BaseIntegrationTest {
 
     @SuppressWarnings("resource")

--- a/src/integrationTest/resources/application-integrationTest.yml
+++ b/src/integrationTest/resources/application-integrationTest.yml
@@ -1,0 +1,11 @@
+spring:
+  flyway:
+    # Fail fast if DB has objects but no Flyway history; prevents silent baselining
+    baseline-on-migrate: false
+    # Ensure a pristine schema before migrations for deterministic tests
+    clean-before-migrate: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,7 +5,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: validate # Validates the schema, does not make changes
+      ddl-auto: validate
     show-sql: false
 management:
   datadog:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,12 +12,15 @@ spring:
   # JPA/Hibernate settings
   jpa:
     hibernate:
-      ddl-auto: update # Automatically updates the schema on startup
+      ddl-auto: validate # Validate schema; Flyway manages migrations
     show-sql: true # Logs SQL statements for debugging
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
 
 server:
   port: 8080
@@ -27,7 +30,6 @@ management:
   datadog:
     metrics:
       export:
-        # Datadog is disabled by default. It is enabled in the 'prod' profile.
         enabled: false
 
 aws:
@@ -36,8 +38,6 @@ aws:
 
 security:
   jwt:
-    # JWT secret must be provided via environment variable SECURITY_JWT_SECRET.
-    # Use a random base64-encoded string with at least 256 bits (32 bytes) of entropy.
     secret: ${SECURITY_JWT_SECRET}
     # 24 hours by default (ms)
     expiration-ms: ${SECURITY_JWT_EXPIRATION_MS:86400000}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
+    clean-disabled: true
 
 server:
   port: 8080

--- a/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,31 @@
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id BIGSERIAL PRIMARY KEY,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    account_non_expired BOOLEAN NOT NULL DEFAULT TRUE,
+    account_non_locked BOOLEAN NOT NULL DEFAULT TRUE,
+    credentials_non_expired BOOLEAN NOT NULL DEFAULT TRUE,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- File metadata
+CREATE TABLE IF NOT EXISTS file_metadata (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    original_filename VARCHAR(1024) NOT NULL,
+    storage_key VARCHAR(512) NOT NULL UNIQUE,
+    size BIGINT NOT NULL,
+    content_type VARCHAR(255) NOT NULL,
+    upload_timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    update_timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_file_metadata_user_id ON file_metadata(user_id);
+
+


### PR DESCRIPTION
## 📋 Summary
Introduce Flyway-based migrations with a V1 initial schema for `users` and `file_metadata`. Switch the app to validate the schema (managed by Flyway) and enable Flyway during integration tests to ensure tests run against the same schema as production.

## 🔄 Type of Change
- [x] ✨ New feature
- [x] 🔧 Refactoring

## 🚀 Changes Made
- Add Flyway dependencies:
  - `org.flywaydb:flyway-core`
  - `org.flywaydb:flyway-database-postgresql`
- Create `V1__initial_schema.sql`:
  - Tables: `users`, `file_metadata` with FK, timestamps, constraints
  - Index: `idx_file_metadata_user_id`
  - Removed redundant non-unique index on `storage_key` (unique constraint already indexes)
- Configure Flyway in `application.yml`:
  - `spring.jpa.hibernate.ddl-auto=validate`
  - `spring.flyway.enabled=true`
  - `spring.flyway.baseline-on-migrate=true`
  - `spring.flyway.clean-disabled=true`
- Ensure integration tests use Flyway (no DDL override in `BaseIntegrationTest`)

## 🧪 Testing
**Test Steps:**
1. Start a clean build and run all tests:
   - `./gradlew clean test integrationTest`
2. Verify:
   - Flyway runs V1 migration against the Testcontainers PostgreSQL DB
   - All tests pass
   - No schema auto-creation by Hibernate (DDL validate only)

## ✅ Checklist
- [ ] Code reviewed by author
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)
- [ ] Ready for review