### PR TITLE
[MISC-00] Removed spotless, don't find much use for it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,6 @@ docker compose down -v
 # Build
 ./gradlew build
 
-# Code formatting
-./gradlew spotlessApply
-
 # Test coverage reports
 ./gradlew test jacocoTestReport              # Unit test coverage only
 ./gradlew jacocoMergedReport                 # Unit + Integration test coverage

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     id("org.springframework.boot") version "3.5.3"
     id("io.spring.dependency-management") version "1.1.7"
     id("java")
-    id("com.diffplug.spotless") version "7.2.1"
     id("jacoco")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,18 +164,3 @@ tasks.register<JacocoReport>("jacocoMergedReport") {
         html.required.set(true)
     }
 }
-
-spotless {
-    java {
-        target("src/**/*.java")
-        importOrder()
-        removeUnusedImports()
-        googleJavaFormat("1.22.0")
-    }
-    // Keep gradle scripts neat
-    format("gradle") {
-        target("**/*.gradle.kts")
-        trimTrailingWhitespace()
-        endWithNewline()
-    }
-}


### PR DESCRIPTION
Removed spotless, I don't find much use for it, I dislike it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Spotless configuration from Gradle build and deletes related code-formatting instructions from the README.
> 
> - **Build/Gradle**:
>   - Remove `spotless { ... }` configuration block from `build.gradle.kts`.
> - **Docs**:
>   - Remove `Code formatting` section and `./gradlew spotlessApply` command from `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcd5caf9afe43b8a50db9e62c3a9e1057af3e560. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->