### PR TITLE
feat: DigitalOcean deployment (Droplet + Spaces) — configurable S3 SSE + hardened compose override

### DIFF
--- a/docker-compose.digitalocean.yml
+++ b/docker-compose.digitalocean.yml
@@ -1,0 +1,89 @@
+# DigitalOcean Droplet + Spaces production override for docker-compose.yml
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.digitalocean.yml up -d --build
+#
+# This is ADDITIVE. It does NOT replace docker-compose.prod.yml (AWS/EC2) — keep
+# both so you can still deploy to AWS. Reads Spaces settings from a Droplet-local
+# .env (see DIGITALOCEAN_MIGRATION.md "DigitalOcean Environment File").
+#
+# COMPOSE MERGE SEMANTICS (important):
+# Compose CONCATENATES list keys (ports, volumes) across -f files — a plain
+# `ports: []` / `volumes: []` does NOT clear the base file's entries. We use the
+# `!reset` / `!override` tags (Docker Compose v2.24.4+ — `!override` requires
+# 2.24.4) to actually drop the inherited dev port bindings and the ${HOME}/.aws
+# mount. After editing, verify:
+#   docker compose -f docker-compose.yml -f docker-compose.digitalocean.yml config
+# and confirm NO /aws mount and NO published 8080 / 5433 / 3000 / 8126 / 4317 / 4318.
+
+services:
+  app:
+    # Mirror the EC2 prod override: the app writes OCR/temp files at runtime.
+    read_only: false
+    cap_add: [ SETUID, SETGID, DAC_READ_SEARCH ]
+    # Drop the base "8080:8080" host publish — the frontend reaches the app over the
+    # internal Docker network, so 8080 must not be exposed on the Droplet.
+    ports: !reset []
+    # Drop the base "${HOME}/.aws:/aws:ro" mount — a Droplet has no ~/.aws; Spaces
+    # creds come from the env vars below.
+    volumes: !reset []
+    environment:
+      DD_SERVICE: file-system-app
+      DD_ENV: prod
+      SPRING_PROFILES_ACTIVE: prod
+      # application-prod.yml requires this and provides no default.
+      SPRING_DATASOURCE_USERNAME: user
+
+      # --- DigitalOcean Spaces (S3-compatible) ---
+      # The endpoint host (region slug) selects the datacenter: nyc3, sfo3, ams3, ...
+      # AWS_REGION is the SDK *signing* region; DigitalOcean's SDK docs use us-east-1.
+      AWS_REGION: ${DO_SPACES_SIGNING_REGION:-us-east-1}
+      AWS_S3_BUCKET: ${DO_SPACES_BUCKET:?set DO_SPACES_BUCKET in .env}
+      AWS_ENDPOINT_URL_S3: https://${DO_SPACES_REGION:?set DO_SPACES_REGION in .env}.digitaloceanspaces.com
+      AWS_ACCESS_KEY_ID: ${DO_SPACES_KEY:?set DO_SPACES_KEY in .env}
+      AWS_SECRET_ACCESS_KEY: ${DO_SPACES_SECRET:?set DO_SPACES_SECRET in .env}
+
+      # Spaces does not support SSE-S3 (AES256). Blank = don't send the header.
+      # On AWS this stays AES256 via application.yml's default.
+      AWS_S3_SERVER_SIDE_ENCRYPTION: ""
+
+      # Droplets have no EC2 instance metadata. Setting AWS_ENDPOINT_URL_S3 makes
+      # AwsConfig use EnvironmentVariableCredentialsProvider, so the keys above are
+      # used directly. Disable profile/config/metadata lookups to avoid surprises.
+      AWS_PROFILE: ""
+      AWS_SHARED_CREDENTIALS_FILE: ""
+      AWS_CONFIG_FILE: ""
+      AWS_EC2_METADATA_DISABLED: "true"
+      AWS_SDK_LOAD_CONFIG: "false"
+
+  postgres-db:
+    # Drop the base "5433:5432" host publish — only the app talks to Postgres, over
+    # the internal network. Never expose the DB on the Droplet.
+    ports: !reset []
+
+  frontend:
+    # !override replaces the base "3000:80" instead of appending, so only 80/443
+    # are published.
+    ports: !override
+      - "80:80"
+      - "443:443/tcp"
+      - "443:443/udp"
+    # !override replaces the base "./client/nginx.conf" mount (which targets the
+    # same /etc/nginx/conf.d/default.conf) with the production HTTPS config —
+    # otherwise both would mount to the same path. Reusing managefiles.duckdns.org
+    # (DO Reserved IP) means file-storage.conf needs no domain edits; the cert must
+    # already exist at /etc/letsencrypt/live/managefiles.duckdns.org/ (copy the whole
+    # /etc/letsencrypt tree from the EC2 box — see TLS And DNS in the runbook).
+    volumes: !override
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./deployment/nginx/file-storage.conf:/etc/nginx/conf.d/default.conf:ro
+
+  datadog:
+    # Drop the base "8126/4317/4318" host publishes — the app sends traces/metrics
+    # over the internal network.
+    ports: !reset []
+    environment:
+      DD_ENV: prod
+      # To run WITHOUT Datadog: `docker compose ... up -d --scale datadog=0`
+      # and add to app:  MANAGEMENT_OTLP_METRICS_EXPORT_ENABLED: "false"
+      # (.secrets/dd_api_key and .secrets/dd_site still need dummy values to start.)

--- a/src/main/java/org/ddamme/config/AwsProperties.java
+++ b/src/main/java/org/ddamme/config/AwsProperties.java
@@ -26,5 +26,14 @@ public class AwsProperties {
         @Min(1)
         @Max(7 * 24 * 60) // S3 presign max is 7 days (10080 minutes)
         private int presignTtlMinutes = 5; // default 5 minutes
+
+        /**
+         * Server-side encryption header sent on upload (PutObject).
+         * "AES256" matches AWS S3 and the AWS IAM policy that REQUIRES
+         * s3:x-amz-server-side-encryption=AES256 on PutObject.
+         * Leave blank/empty to send no SSE header — required for DigitalOcean
+         * Spaces, which does not support SSE-S3.
+         */
+        private String serverSideEncryption = "AES256";
     }
 }

--- a/src/main/java/org/ddamme/service/S3StorageService.java
+++ b/src/main/java/org/ddamme/service/S3StorageService.java
@@ -64,15 +64,22 @@ public class S3StorageService implements StorageService {
 
             String contentDisposition = "attachment; filename=\"" + ascii + "\"; filename*=UTF-8''" + rfc5987;
 
-            PutObjectRequest putObjectRequest =
+            PutObjectRequest.Builder putObjectRequestBuilder =
                     PutObjectRequest.builder()
                             .bucket(bucketName)
                             .key(storageKey)
                             .contentType(contentType)
                             .contentDisposition(contentDisposition)
-                            .contentLength(file.getSize())
-                            .serverSideEncryption(ServerSideEncryption.AES256)
-                            .build();
+                            .contentLength(file.getSize());
+
+            // Only send the SSE header when configured. AWS keeps "AES256"
+            // (its IAM policy requires it); DigitalOcean Spaces sets this blank.
+            String sse = awsProperties.getS3().getServerSideEncryption();
+            if (sse != null && !sse.isBlank()) {
+                putObjectRequestBuilder.serverSideEncryption(ServerSideEncryption.fromValue(sse.trim()));
+            }
+
+            PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
 
             s3Client.putObject(
                     putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,9 @@ aws:
   s3:
     bucket-name: ${AWS_S3_BUCKET:filesystem-s3}
     presign-ttl-minutes: ${AWS_S3_PRESIGN_TTL_MINUTES:5}
+    # AES256 = current AWS behavior (and the AWS IAM policy requires it).
+    # DigitalOcean Spaces sets AWS_S3_SERVER_SIDE_ENCRYPTION="" to disable it.
+    server-side-encryption: ${AWS_S3_SERVER_SIDE_ENCRYPTION:AES256}
 
 metrics:
   s3:


### PR DESCRIPTION
## Summary
Adds the ability to deploy this app to **DigitalOcean** (Droplet + Spaces) without
disturbing the existing AWS (EC2 + S3) path. Fully **additive** —
`docker-compose.prod.yml` (AWS) is untouched; this adds a parallel
`docker-compose.digitalocean.yml` override and makes the one S3 behavior that isn't
Spaces-compatible (server-side encryption) configurable.

## Why
DigitalOcean Spaces is S3-compatible but **does not support SSE-S3** (`AES256`), which
the app currently sends unconditionally on every upload. On AWS that same header is
*required* by the bucket's IAM policy, so it can't just be removed — it has to be
configurable: keep `AES256` for AWS, blank for Spaces.

## Changes
- **Configurable S3 SSE** (`AwsProperties`, `S3StorageService`, `application.yml`):
  - New `aws.s3.server-side-encryption` property (`AWS_S3_SERVER_SIDE_ENCRYPTION`),
    default `AES256`.
  - `S3StorageService.upload` only sends the SSE header when the value is non-blank.
  - AWS behavior unchanged; Spaces sets it `""`.
- **`docker-compose.digitalocean.yml`** (new) — Droplet/Spaces override:
  - Points the app at Spaces (regional endpoint + env-var credentials),
    `SPRING_PROFILES_ACTIVE=prod`.
  - Uses Compose **`!reset` / `!override`** (v2.24.4+) to actually drop the base file's
    dev port publishes (`8080/5433/3000/8126/4317/4318`) and the `${HOME}/.aws` mount —
    so only `80/443` are exposed.
  - **Fail-fast** on missing Spaces config via `${DO_SPACES_*:?}` guards.

## Design decisions
- **SSE default stays `AES256`** so the AWS deployment and its
  `s3:x-amz-server-side-encryption=AES256` IAM policy keep working with no env changes.
- **`!reset`/`!override`, not `volumes: []`** — Compose *concatenates* list keys across
  `-f` files, so a plain empty list does **not** clear inherited entries (verified with
  `docker compose config`). These tags require Compose **2.24.4+**.
- **AWS path untouched** — hardening `docker-compose.prod.yml` is a separate concern.

## Verification
- ✅ 42 unit tests pass; `compileJava` clean.
- ✅ Integration tests run in CI on this PR (`./gradlew clean test integrationTest`).
- ✅ **Deployed live** to a DigitalOcean Droplet (Ubuntu 24.04; Spaces in nyc3):
  - All 4 containers healthy; only `80/443` published (postgres/app/datadog
    internal-only — verified via `docker ps`).
  - TLS (Let's Encrypt) + frontend serving (`HTTP/2 200`).
  - Auth end-to-end (register returns a JWT; Flyway built the schema on a fresh DB).
  - **Spaces upload + OCR + full-text search verified** (uploaded a screenshot →
    OCR'd → searchable), using a limited Read/Write/Delete Spaces key, no `403`.

## Follow-ups (not in this PR)
- `AwsConfig` logs "Using LocalStack S3 endpoint" for *any* custom endpoint — cosmetic rename.
- Local `integrationTest` can't run against Docker Engine 29 with Testcontainers 1.20.2
  (API handshake returns HTTP 400) — bump `testcontainers-bom` as a separate DX commit.
- `.docx`/`.txt` content isn't text-extracted (only images via OCR + PDFs) — separate feature.
- Cert auto-renewal cron + frontend restart hook on the Droplet.

## Out of scope
- No data migration (fresh DB + empty Space, by design).
- No changes to the AWS deployment path.
