### PR TITLE
feat(ui): cool-white theme across app — top bar, login, dashboard & Deep Search (responsive)

### DIFF
--- a/client/src/components/files/FileFilters.tsx
+++ b/client/src/components/files/FileFilters.tsx
@@ -50,14 +50,14 @@ export function FileFilters({
     };
 
     return (
-        <div className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-lg bg-white p-4 shadow">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4 card p-4">
             {/* Left side: Type filter + Search */}
             <div className="flex items-center gap-3">
                 <select
                     id="type-filter"
                     value={typeFilter}
                     onChange={(e) => onTypeFilterChange(e.target.value as FileTypeFilter)}
-                    className="rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    className="rounded-lg border border-border bg-surface py-1.5 pl-3 pr-8 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                     aria-label="Filter by file type"
                 >
                     {typeFilterOptions.map((option) => (
@@ -72,7 +72,7 @@ export function FileFilters({
                     {!isSearchExpanded ? (
                         <button
                             onClick={() => setIsSearchExpanded(true)}
-                            className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                            className="inline-flex items-center gap-1 rounded-lg border border-accent bg-accent px-3 py-1.5 text-sm font-medium text-white transition hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent/30"
                             aria-label="Open search"
                         >
                             <Search size={16}/>
@@ -81,13 +81,13 @@ export function FileFilters({
                     ) : (
                         <div className="flex items-center gap-2">
                             <div className="relative">
-                                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"/>
+                                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-faint"/>
                                 <input
                                     type="text"
                                     value={searchQuery}
                                     onChange={(e) => onSearchChange(e.target.value)}
                                     placeholder="Search files..."
-                                    className="w-64 rounded-md border border-gray-300 py-1.5 pl-10 pr-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                    className="w-64 rounded-lg border border-border bg-surface py-1.5 pl-10 pr-3 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                                     autoFocus
                                 />
                             </div>
@@ -96,7 +96,7 @@ export function FileFilters({
                                     setIsSearchExpanded(false);
                                     onSearchChange('');
                                 }}
-                                className="text-gray-400 hover:text-gray-600 transition"
+                                className="text-faint hover:text-muted transition"
                                 aria-label="Close search"
                             >
                                 <X size={18}/>
@@ -108,11 +108,11 @@ export function FileFilters({
 
             {/* Right side: Sort */}
             <div className="flex items-center gap-2">
-                <label className="text-sm font-medium text-gray-700">Sort:</label>
+                <label className="text-sm font-medium text-muted">Sort:</label>
                 <select
                     value={sortField}
                     onChange={(e) => onSortChange(e.target.value as SortField)}
-                    className="rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    className="rounded-lg border border-border bg-surface py-1.5 pl-3 pr-8 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                     aria-label="Sort files by"
                 >
                     {sortOptions.map((option) => (
@@ -123,7 +123,7 @@ export function FileFilters({
                 </select>
                 <button
                     onClick={toggleSortOrder}
-                    className="inline-flex items-center rounded-md border border-gray-300 bg-white p-1.5 text-gray-700 hover:bg-gray-50"
+                    className="inline-flex items-center rounded-lg border border-border bg-surface p-1.5 text-ink transition hover:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                     title={`Sort order: ${sortOrder === 'asc' ? 'Ascending' : 'Descending'}`}
                     aria-label={`Toggle sort order (currently ${sortOrder === 'asc' ? 'ascending' : 'descending'})`}
                 >

--- a/client/src/components/files/FileFilters.tsx
+++ b/client/src/components/files/FileFilters.tsx
@@ -52,7 +52,7 @@ export function FileFilters({
     return (
         <div className="mb-6 flex flex-wrap items-center justify-between gap-4 card p-4">
             {/* Left side: Type filter + Search */}
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
                 <select
                     id="type-filter"
                     value={typeFilter}
@@ -87,7 +87,7 @@ export function FileFilters({
                                     value={searchQuery}
                                     onChange={(e) => onSearchChange(e.target.value)}
                                     placeholder="Search files..."
-                                    className="w-64 rounded-lg border border-border bg-surface py-1.5 pl-10 pr-3 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+                                    className="w-full sm:w-64 rounded-lg border border-border bg-surface py-1.5 pl-10 pr-3 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                                     autoFocus
                                 />
                             </div>

--- a/client/src/components/files/FilesTable.tsx
+++ b/client/src/components/files/FilesTable.tsx
@@ -38,60 +38,60 @@ export function FilesTable({files, onPreview, onDownload, onDelete, onCopyLink}:
     }, [uploads]);
     if (files.length === 0) {
         return (
-            <div className="text-center py-12 text-gray-500">
+            <div className="text-center py-12 text-muted">
                 <p>No files yet. Upload your first file above!</p>
             </div>
         );
     }
 
     return (
-        <div className="bg-white rounded-lg shadow overflow-hidden">
-            <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+        <div className="card overflow-hidden">
+            <table className="min-w-full">
+                <thead className="bg-canvas">
                 <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-faint uppercase">
                         Name
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-faint uppercase">
                         Size
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-faint uppercase">
                         Type
                     </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    <th className="px-6 py-3 text-left text-xs font-medium text-faint uppercase">
                         Uploaded
                     </th>
-                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                    <th className="px-6 py-3 text-right text-xs font-medium text-faint uppercase">
                         Actions
                     </th>
                 </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
+                <tbody>
                 {files.map((file) => {
                     const isHighlighted = highlightedIds.has(file.id);
                     return (
                         <tr
                             key={file.id}
-                            className={`hover:bg-gray-50 transition-colors duration-1000 ${
-                                isHighlighted ? 'bg-blue-50' : ''
+                            className={`border-t border-line hover:bg-canvas transition-colors duration-1000 ${
+                                isHighlighted ? 'bg-accent-weak' : ''
                             }`}
                         >
-                            <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                            <td className="px-6 py-4 text-sm font-medium text-ink">
                                 <button
                                     onClick={() => onPreview(file.id)}
-                                    className="text-left hover:text-blue-600 hover:underline transition truncate max-w-xs block"
+                                    className="text-left text-ink font-medium hover:text-accent hover:underline transition truncate max-w-xs block"
                                     title={`${file.originalFilename} - Click to preview`}
                                 >
                                     {file.originalFilename}
                                 </button>
                             </td>
-                            <td className="px-6 py-4 text-sm text-gray-500">
+                            <td className="px-6 py-4 text-sm text-muted">
                                 {formatFileSize(file.size)}
                             </td>
-                            <td className="px-6 py-4 text-sm text-gray-500">
+                            <td className="px-6 py-4 text-sm text-muted">
                                 {formatFileType(file.contentType)}
                             </td>
-                            <td className="px-6 py-4 text-sm text-gray-500">
+                            <td className="px-6 py-4 text-sm text-muted">
                                 {formatRelativeTime(file.uploadTimestamp)}
                             </td>
                             <td className="px-6 py-4 text-sm text-right space-x-2">
@@ -100,7 +100,7 @@ export function FilesTable({files, onPreview, onDownload, onDelete, onCopyLink}:
                                         onClick={() => onPreview(file.id)}
                                         aria-label={`Preview ${file.originalFilename}`}
                                         title="Preview"
-                                        className="inline-flex items-center text-purple-600 hover:text-purple-800"
+                                        className="inline-flex items-center text-accent hover:text-accent-strong"
                                     >
                                         <Eye size={16}/>
                                     </button>
@@ -130,7 +130,7 @@ export function FilesTable({files, onPreview, onDownload, onDelete, onCopyLink}:
                                     onClick={() => onDelete(file.id)}
                                     aria-label={`Delete ${file.originalFilename}`}
                                     title="Delete"
-                                    className="inline-flex items-center text-red-600 hover:text-red-800"
+                                    className="inline-flex items-center text-red-500 hover:text-red-700"
                                 >
                                     <Trash2 size={16}/>
                                 </button>

--- a/client/src/components/files/PaginationBar.tsx
+++ b/client/src/components/files/PaginationBar.tsx
@@ -16,38 +16,38 @@ export function PaginationBar({
     const displayPage = currentPage + 1; // API is 0-based, display is 1-based
 
     return (
-        <div className="flex items-center justify-between px-6 py-4 bg-white border-t">
+        <div className="mt-3 flex items-center justify-between rounded-2xl border border-border bg-surface px-6 py-4 text-muted shadow-soft">
             <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-700">Show</span>
+                <span className="text-sm text-muted">Show</span>
                 <select
                     value={pageSize}
                     onChange={(e) => onPageSizeChange(Number(e.target.value))}
-                    className="rounded border px-2 py-1 text-sm"
+                    className="rounded-lg border border-border bg-surface px-2 py-1 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                 >
                     <option value={20}>20</option>
                     <option value={50}>50</option>
                     <option value={100}>100</option>
                 </select>
-                <span className="text-sm text-gray-700">per page</span>
+                <span className="text-sm text-muted">per page</span>
             </div>
 
             <div className="flex items-center gap-2">
                 <button
                     onClick={() => onPageChange(currentPage - 1)}
                     disabled={currentPage === 0}
-                    className="px-3 py-1 rounded border disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+                    className="rounded-lg border border-border bg-surface px-3 py-1 text-sm text-ink transition hover:border-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-border"
                 >
                     « Prev
                 </button>
 
-                <span className="text-sm text-gray-700">
+                <span className="text-sm text-muted">
           Page {displayPage} of {totalPages}
         </span>
 
                 <button
                     onClick={() => onPageChange(currentPage + 1)}
                     disabled={currentPage === totalPages - 1}
-                    className="px-3 py-1 rounded border disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50"
+                    className="rounded-lg border border-border bg-surface px-3 py-1 text-sm text-ink transition hover:border-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-border"
                 >
                     Next »
                 </button>

--- a/client/src/components/files/PaginationBar.tsx
+++ b/client/src/components/files/PaginationBar.tsx
@@ -16,7 +16,7 @@ export function PaginationBar({
     const displayPage = currentPage + 1; // API is 0-based, display is 1-based
 
     return (
-        <div className="mt-3 flex items-center justify-between rounded-2xl border border-border bg-surface px-6 py-4 text-muted shadow-soft">
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-border bg-surface px-6 py-4 text-muted shadow-soft">
             <div className="flex items-center gap-2">
                 <span className="text-sm text-muted">Show</span>
                 <select

--- a/client/src/components/files/UploadZone.tsx
+++ b/client/src/components/files/UploadZone.tsx
@@ -181,16 +181,16 @@ export function UploadZone() {
         <>
             <div
                 {...getRootProps()}
-                className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition ${
-                    isDragActive ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-gray-400'
+                className={`rounded-2xl border-2 border-dashed bg-accent-weak/40 p-10 text-center cursor-pointer transition ${
+                    isDragActive ? 'border-accent bg-accent-weak/70' : 'border-accent/40 hover:border-accent'
                 }`}
             >
                 <input {...getInputProps()} />
-                <UploadIcon className="mx-auto h-12 w-12 text-gray-400"/>
-                <p className="mt-2 text-sm text-gray-600">
+                <UploadIcon className="mx-auto h-9 w-9 text-accent"/>
+                <p className="mt-2 text-sm font-semibold text-ink">
                     Drag & drop files here, or click to select
                 </p>
-                <p className="text-xs text-gray-500 mt-1">Max 10 MB per file</p>
+                <p className="text-xs text-faint mt-1">Max 10 MB per file</p>
             </div>
 
             {/* Duplicate File Dialog */}

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -3,7 +3,7 @@ import {TopBar} from './TopBar';
 
 export function AppShell({children}: { children: ReactNode }) {
     return (
-        <div className="min-h-screen bg-gray-50">
+        <div className="min-h-screen">
             <TopBar/>
             <main className="container mx-auto px-4 py-8">{children}</main>
         </div>

--- a/client/src/components/layout/TopBar.tsx
+++ b/client/src/components/layout/TopBar.tsx
@@ -1,27 +1,36 @@
-import {Link, useLocation} from 'react-router-dom';
+import {useState, type FormEvent} from 'react';
+import {Link, useLocation, useNavigate} from 'react-router-dom';
+import {FolderClosed, Search} from 'lucide-react';
 import {useAuth} from '@/hooks/useAuth';
 import {FEATURE_FLAGS} from '@/lib/featureFlags';
 
 export function TopBar() {
     const {user, logout} = useAuth();
     const location = useLocation();
+    const navigate = useNavigate();
+    const [quickFind, setQuickFind] = useState('');
 
     const isActive = (path: string) => location.pathname === path;
 
+    const handleQuickFind = (e: FormEvent) => {
+        e.preventDefault();
+        const q = quickFind.trim();
+        if (q) {
+            navigate('/search?q=' + encodeURIComponent(q));
+        }
+    };
+
     return (
         <header className="sticky top-0 z-10 border-b border-border bg-white/70 backdrop-blur">
-            <div className="container mx-auto flex items-center justify-between px-4 py-4">
-                <div className="flex items-center gap-8">
+            <div className="container mx-auto flex flex-wrap items-center justify-between gap-y-2 px-4 py-4">
+                <div className="flex min-w-0 items-center gap-8">
                     <div className="flex items-center gap-4">
                         <div className="flex items-center gap-3">
                             <span
                                 className="grid h-8 w-8 place-items-center rounded-lg text-white"
                                 style={{background: 'linear-gradient(155deg,#6d63f0,#5b50e6 55%,#4b40d4)'}}
                             >
-                                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                     strokeWidth="2">
-                                    <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-                                </svg>
+                                <FolderClosed size={17} strokeWidth={2}/>
                             </span>
                             <h1 className="text-2xl font-bold">File Storage</h1>
                         </div>
@@ -55,24 +64,32 @@ export function TopBar() {
                     </nav>
                 </div>
                 <div className="flex items-center gap-4">
-                    <Link
-                        to="/search"
-                        className="flex items-center gap-2 rounded-lg border border-border bg-canvas px-3 py-1.5 text-sm text-faint"
+                    <form
+                        onSubmit={handleQuickFind}
+                        className="relative hidden items-center md:flex"
+                        role="search"
                     >
-                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                             strokeWidth="2">
-                            <circle cx="11" cy="11" r="7"/>
-                            <path d="m20 20-3.5-3.5"/>
-                        </svg>
-                        Quick find…
-                    </Link>
+                        <Search
+                            size={15}
+                            strokeWidth={2}
+                            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-faint"
+                        />
+                        <input
+                            type="text"
+                            value={quickFind}
+                            onChange={(e) => setQuickFind(e.target.value)}
+                            placeholder="Quick find…"
+                            aria-label="Quick find"
+                            className="w-48 rounded-lg border border-border bg-canvas py-1.5 pl-9 pr-3 text-sm text-ink placeholder:text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+                        />
+                    </form>
                     <span
-                        className="grid h-8 w-8 place-items-center rounded-full text-sm font-bold text-white"
+                        className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-sm font-bold text-white"
                         style={{background: 'linear-gradient(155deg,#6d63f0,#5b50e6 55%,#4b40d4)'}}
                     >
                         {user?.username?.charAt(0).toUpperCase()}
                     </span>
-                    <span className="text-sm text-muted">{user?.username}</span>
+                    <span className="hidden text-sm text-muted sm:inline">{user?.username}</span>
                     <button onClick={logout} className="btn-secondary">
                         Sign Out
                     </button>

--- a/client/src/components/layout/TopBar.tsx
+++ b/client/src/components/layout/TopBar.tsx
@@ -9,42 +9,70 @@ export function TopBar() {
     const isActive = (path: string) => location.pathname === path;
 
     return (
-        <header className="border-b border-gray-200 bg-white">
+        <header className="sticky top-0 z-10 border-b border-border bg-white/70 backdrop-blur">
             <div className="container mx-auto flex items-center justify-between px-4 py-4">
                 <div className="flex items-center gap-8">
                     <div className="flex items-center gap-4">
-                        <h1 className="text-2xl font-bold">File Storage</h1>
+                        <div className="flex items-center gap-3">
+                            <span
+                                className="grid h-8 w-8 place-items-center rounded-lg text-white"
+                                style={{background: 'linear-gradient(155deg,#6d63f0,#5b50e6 55%,#4b40d4)'}}
+                            >
+                                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                     strokeWidth="2">
+                                    <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                                </svg>
+                            </span>
+                            <h1 className="text-2xl font-bold">File Storage</h1>
+                        </div>
                         {FEATURE_FLAGS.SHOW_ENV_BADGE && (
                             <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
                   {import.meta.env.MODE}
                 </span>
                         )}
                     </div>
-                    <nav className="flex items-center gap-6">
+                    <nav className="flex items-center gap-2">
                         <Link
                             to="/"
-                            className={`text-sm font-medium transition-colors ${
-                                isActive('/') 
-                                    ? 'text-blue-600' 
-                                    : 'text-gray-600 hover:text-gray-900'
+                            className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                                isActive('/')
+                                    ? 'bg-accent-weak text-accent'
+                                    : 'text-muted hover:bg-line hover:text-ink'
                             }`}
                         >
                             Files
                         </Link>
                         <Link
                             to="/search"
-                            className={`text-sm font-medium transition-colors ${
-                                isActive('/search') 
-                                    ? 'text-blue-600' 
-                                    : 'text-gray-600 hover:text-gray-900'
+                            className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                                isActive('/search')
+                                    ? 'bg-accent-weak text-accent'
+                                    : 'text-muted hover:bg-line hover:text-ink'
                             }`}
                         >
-                            Search
+                            Deep Search
                         </Link>
                     </nav>
                 </div>
                 <div className="flex items-center gap-4">
-                    <span className="text-sm text-gray-600">{user?.username}</span>
+                    <Link
+                        to="/search"
+                        className="flex items-center gap-2 rounded-lg border border-border bg-canvas px-3 py-1.5 text-sm text-faint"
+                    >
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                             strokeWidth="2">
+                            <circle cx="11" cy="11" r="7"/>
+                            <path d="m20 20-3.5-3.5"/>
+                        </svg>
+                        Quick find…
+                    </Link>
+                    <span
+                        className="grid h-8 w-8 place-items-center rounded-full text-sm font-bold text-white"
+                        style={{background: 'linear-gradient(155deg,#6d63f0,#5b50e6 55%,#4b40d4)'}}
+                    >
+                        {user?.username?.charAt(0).toUpperCase()}
+                    </span>
+                    <span className="text-sm text-muted">{user?.username}</span>
                     <button onClick={logout} className="btn-secondary">
                         Sign Out
                     </button>
@@ -53,4 +81,3 @@ export function TopBar() {
         </header>
     );
 }
-

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2,17 +2,35 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+    color: #161a23;
+    min-height: 100vh;
+    background-color: #f6f8fb;
+    background:
+        radial-gradient(900px 380px at 50% -120px, rgba(91, 80, 230, .07), rgba(91, 80, 230, 0) 70%),
+        radial-gradient(1200px 700px at 50% -8%, #eef1f7 0%, #f3f6fa 46%, #f6f8fb 100%);
+    background-attachment: fixed;
+}
+
 @layer components {
     .btn-primary {
-        @apply rounded bg-blue-600 px-4 py-2 font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50;
+        @apply rounded-lg bg-accent px-4 py-2 font-medium text-white shadow-soft transition hover:brightness-105 focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:cursor-not-allowed disabled:opacity-50;
     }
 
     .btn-secondary {
-        @apply rounded border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50;
+        @apply rounded-lg border border-border bg-surface px-4 py-2 font-medium text-ink shadow-soft transition hover:border-faint focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-50;
     }
 
     .btn-danger {
-        @apply rounded bg-red-600 px-4 py-2 font-medium text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50;
+        @apply rounded-lg bg-red-600 px-4 py-2 font-medium text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50;
+    }
+
+    .card {
+        @apply rounded-2xl border border-border bg-surface shadow-card;
+    }
+
+    .input {
+        @apply w-full rounded-lg border border-border bg-canvas px-3 py-2 text-ink transition focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/30;
     }
 }
 

--- a/client/src/pages/FilesPage.tsx
+++ b/client/src/pages/FilesPage.tsx
@@ -122,12 +122,12 @@ export function FilesPage() {
         <>
             <div className="space-y-8">
                 <section>
-                    <h2 className="text-2xl font-bold mb-4">Upload Files</h2>
+                    <h2 className="text-2xl font-bold text-ink mb-4">Upload Files</h2>
                     <UploadZone/>
                 </section>
 
                 <section>
-                    <h2 className="text-2xl font-bold mb-4">Your Files</h2>
+                    <h2 className="text-2xl font-bold text-ink mb-4">Your Files</h2>
 
                     <FileFilters
                         sortField={sortField}
@@ -139,7 +139,7 @@ export function FilesPage() {
                         onSearchChange={setSearchQuery}
                     />
 
-                    <div className="rounded-lg shadow">
+                    <div>
                         <FilesTable
                             files={filteredAndSortedFiles}
                             onPreview={(id) => setPreviewFileId(id)}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -76,15 +76,33 @@ export function LoginPage() {
     }
 
     return (
-        <div className="flex min-h-screen items-center justify-center bg-gray-50">
-            <div className="w-full max-w-md space-y-8 rounded-lg bg-white p-8 shadow">
-                <h2 className="text-center text-3xl font-bold">File Storage</h2>
+        <div className="flex min-h-screen items-center justify-center">
+            <div className="card w-full max-w-sm p-8">
+                <div className="mb-7 flex flex-col items-center gap-3">
+                    <span
+                        className="grid h-12 w-12 place-items-center rounded-xl text-white shadow-[0_10px_24px_-8px_rgba(91,80,230,.6)]"
+                        style={{background: 'linear-gradient(155deg,#6d63f0,#5b50e6 55%,#4b40d4)'}}
+                    >
+                        <svg
+                            width="26"
+                            height="26"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.9"
+                        >
+                            <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                        </svg>
+                    </span>
+                    <h2 className="text-2xl font-bold text-ink">File Storage</h2>
+                    <p className="text-sm text-muted">Sign in to your files</p>
+                </div>
                 <form
                     onSubmit={handleLogin}
-                    className={`space-y-6 ${hasError ? 'animate-shake' : ''}`}
+                    className={`space-y-5 ${hasError ? 'animate-shake' : ''}`}
                 >
                     <div>
-                        <label htmlFor="username" className="block text-sm font-medium">
+                        <label htmlFor="username" className="block text-sm font-medium text-ink">
                             Username
                         </label>
                         <input
@@ -92,11 +110,11 @@ export function LoginPage() {
                             name="username"
                             type="text"
                             required
-                            className="mt-1 block w-full rounded border p-2"
+                            className="input mt-1.5"
                         />
                     </div>
                     <div>
-                        <label htmlFor="password" className="block text-sm font-medium">
+                        <label htmlFor="password" className="block text-sm font-medium text-ink">
                             Password
                         </label>
                         <input
@@ -104,17 +122,17 @@ export function LoginPage() {
                             name="password"
                             type="password"
                             required
-                            className="mt-1 block w-full rounded border p-2"
+                            className="input mt-1.5"
                         />
                     </div>
                     <button type="submit" disabled={isLoading} className="btn-primary w-full">
                         {isLoading ? 'Logging in...' : 'Login'}
                     </button>
                 </form>
-                <div className="text-center">
-                    <p className="text-sm text-gray-600">
+                <div className="mt-6 text-center">
+                    <p className="text-sm text-muted">
                         Don't have an account?{' '}
-                        <Link to="/register" className="font-medium text-blue-600 hover:text-blue-500">
+                        <Link to="/register" className="font-medium text-accent">
                             Sign up
                         </Link>
                     </p>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import {type FormEvent, useEffect, useState} from 'react';
 import {Link, useNavigate} from 'react-router-dom';
+import {FolderClosed} from 'lucide-react';
 import {toast} from 'sonner';
 import {useAuth} from '@/hooks/useAuth';
 import {api, ApiError} from '@/api/client';
@@ -83,16 +84,7 @@ export function LoginPage() {
                         className="grid h-12 w-12 place-items-center rounded-xl text-white shadow-[0_10px_24px_-8px_rgba(91,80,230,.6)]"
                         style={{background: 'linear-gradient(155deg,#6d63f0,#5b50e6 55%,#4b40d4)'}}
                     >
-                        <svg
-                            width="26"
-                            height="26"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.9"
-                        >
-                            <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                        </svg>
+                        <FolderClosed size={26} strokeWidth={1.9} />
                     </span>
                     <h2 className="text-2xl font-bold text-ink">File Storage</h2>
                     <p className="text-sm text-muted">Sign in to your files</p>

--- a/client/src/pages/SearchPage.tsx
+++ b/client/src/pages/SearchPage.tsx
@@ -1,14 +1,21 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { SearchBar } from '../components/search/SearchBar';
 import { SearchResults } from '../components/search/SearchResults';
 import { SearchPagination } from '../components/search/SearchPagination';
 import { TextPreviewModal } from '../components/search/TextPreviewModal';
 import { useSearch } from '../hooks/useSearch';
 import type { SearchCursor } from '../types/search';
-import { Loader2 } from 'lucide-react';
+import { FileSearch, Loader2 } from 'lucide-react';
 
 export function SearchPage() {
-  const [query, setQuery] = useState('');
+  const [searchParams] = useSearchParams();
+
+  // Seed the query from the ?q param on mount so the quick-find entry point
+  // (which navigates to /search?q=...) genuinely runs Deep Search.
+  const initialQuery = searchParams.get('q')?.trim() ?? '';
+
+  const [query, setQuery] = useState(initialQuery);
   const [cursors, setCursors] = useState<SearchCursor[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [previewFileId, setPreviewFileId] = useState<number | null>(null);
@@ -57,26 +64,26 @@ export function SearchPage() {
     <div className="container mx-auto px-4 py-8 max-w-5xl">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Search Files</h1>
-        <p className="text-gray-600">
+        <h1 className="text-3xl font-bold mb-2 text-ink">Deep Search</h1>
+        <p className="text-muted">
           Search across all your files using full-text search. Supports phrase search, AND, OR operators.
         </p>
       </div>
 
       {/* Search bar */}
       <div className="mb-8">
-        <SearchBar 
-          onSearch={handleSearch} 
+        <SearchBar
+          onSearch={handleSearch}
           initialQuery={query}
           placeholder="Search for text in your files..."
         />
         {query && (
-          <div className="mt-2 text-sm text-gray-600">
+          <div className="mt-2 text-sm text-muted">
             <p className="font-medium">Search tips:</p>
             <ul className="list-disc list-inside mt-1 space-y-1">
-              <li>Use quotes for exact phrases: <code className="bg-gray-100 px-1 rounded">"machine learning"</code></li>
-              <li>Combine terms with AND: <code className="bg-gray-100 px-1 rounded">cats AND dogs</code></li>
-              <li>Find either term with OR: <code className="bg-gray-100 px-1 rounded">cats OR dogs</code></li>
+              <li>Use quotes for exact phrases: <code className="bg-canvas px-1 rounded">"machine learning"</code></li>
+              <li>Combine terms with AND: <code className="bg-canvas px-1 rounded">cats AND dogs</code></li>
+              <li>Find either term with OR: <code className="bg-canvas px-1 rounded">cats OR dogs</code></li>
             </ul>
           </div>
         )}
@@ -85,8 +92,8 @@ export function SearchPage() {
       {/* Loading state */}
       {isLoading && (
         <div className="flex flex-col items-center justify-center py-16 gap-4">
-          <Loader2 className="animate-spin text-blue-600" size={48} />
-          <p className="text-gray-600">Searching...</p>
+          <Loader2 className="animate-spin text-accent" size={48} />
+          <p className="text-muted">Searching...</p>
         </div>
       )}
 
@@ -104,8 +111,8 @@ export function SearchPage() {
       {data && !isLoading && (
         <>
           <div className="mb-6">
-            <p className="text-gray-600">
-              Found <span className="font-medium">{data.count}</span> result{data.count !== 1 ? 's' : ''}
+            <p className="text-muted">
+              Found <span className="font-medium text-ink">{data.count}</span> result{data.count !== 1 ? 's' : ''}
               {currentPage > 1 && ` (page ${currentPage})`}
             </p>
           </div>
@@ -131,20 +138,9 @@ export function SearchPage() {
 
       {/* Empty state (no query) */}
       {!query && !isLoading && (
-        <div className="text-center py-16 text-gray-500">
-          <svg 
-            className="mx-auto mb-4 opacity-50" 
-            width="64" 
-            height="64" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            stroke="currentColor"
-            strokeWidth="1.5"
-          >
-            <circle cx="11" cy="11" r="8" />
-            <path d="m21 21-4.35-4.35" />
-          </svg>
-          <p className="text-lg">Start searching your files</p>
+        <div className="text-center py-16 text-faint">
+          <FileSearch className="mx-auto mb-4" size={64} strokeWidth={1.5} />
+          <p className="text-lg text-muted">Start searching your files</p>
           <p className="text-sm mt-2">Enter a search term above to find text in your uploaded files</p>
         </div>
       )}
@@ -159,4 +155,3 @@ export function SearchPage() {
     </div>
   );
 }
-

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -1,13 +1,45 @@
 import '@testing-library/jest-dom';
 import {cleanup} from '@testing-library/react';
-import {afterEach} from 'vitest';
+import {afterEach, beforeEach, vi} from 'vitest';
+
+function createStorageMock(): Storage {
+    let store: Record<string, string> = {};
+
+    return {
+        get length(): number {
+            return Object.keys(store).length;
+        },
+        getItem(key: string): string | null {
+            return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+        },
+        setItem(key: string, value: string): void {
+            store[String(key)] = String(value);
+        },
+        removeItem(key: string): void {
+            delete store[String(key)];
+        },
+        clear(): void {
+            store = {};
+        },
+        key(index: number): string | null {
+            const keys = Object.keys(store);
+            return index >= 0 && index < keys.length ? keys[index] : null;
+        },
+    } as Storage;
+}
+
+function installStorageMocks(): void {
+    vi.stubGlobal('localStorage', createStorageMock());
+    vi.stubGlobal('sessionStorage', createStorageMock());
+}
+
+// Install once at module load so storage is available before any test runs.
+installStorageMocks();
+
+beforeEach(() => {
+    installStorageMocks();
+});
 
 afterEach(() => {
     cleanup();
 });
-
-
-
-
-
-

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -3,6 +3,20 @@ export default {
     content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
     theme: {
         extend: {
+            colors: {
+                accent: {DEFAULT: '#5b50e6', weak: '#ecebfd', strong: '#4b40d4'},
+                canvas: '#f6f8fb',
+                surface: '#ffffff',
+                ink: '#161a23',
+                muted: '#646c7e',
+                faint: '#9aa1b2',
+                border: '#e7eaf1',
+                line: '#eef1f6',
+            },
+            boxShadow: {
+                card: '0 1px 2px rgba(20,24,40,.04), 0 8px 24px -16px rgba(20,24,40,.22)',
+                soft: '0 1px 2px rgba(20,24,40,.05), 0 2px 6px -3px rgba(20,24,40,.12)',
+            },
             keyframes: {
                 shake: {
                     '0%, 100%': {transform: 'translateX(0)'},


### PR DESCRIPTION
## Summary
Restyles the frontend to one calm "white-but-not-plain" theme and refreshes the top bar,
login, dashboard, and the full-text search page. Renames the nav **"Search" → "Deep Search"**
(full-text + OCR search across file contents, vs. the front filter that matches filenames).
No backend/API/data changes — styling + one small UX wiring (`?q` quick-find) + a test-harness fix.

## Changes
**Theme foundation**
- `tailwind.config.js`: `accent`/`canvas`/`surface`/`ink`/`muted`/`faint`/`border`/`line` colors + `card`/`soft` shadows (existing `shake` kept).
- `index.css`: white-not-plain page background; `.btn-*` on the accent system; reusable `.card` / `.input`.

**Top bar** (`TopBar.tsx`) — frosted sticky bar, lucide `FolderClosed` brand mark, active-pill nav, **Deep Search** rename, gradient avatar; a **real quick-find search form** that navigates to `/search?q=…` (no ⌘K). Fully responsive (quick-find/username hide on small screens, row wraps). `AppShell.tsx` drops the gray bg.

**Login** (`LoginPage.tsx`) — brand mark + "Sign in to your files", focus-ring inputs, accent button; all auth logic untouched; lucide icon.

**Dashboard** (`UploadZone`, `FileFilters`, `FilesTable`, `PaginationBar`, `FilesPage`) — white cards, hairline rows, accent actions; filters + pagination wrap responsively. Props/handlers intact.

**Deep Search page** (`SearchPage.tsx`) — themed to match, lucide empty-state icon, and reads the `?q` param so the top-bar quick-find runs a real search. Pagination/preview logic unchanged.

**Test harness** (`test/setup.ts`) — adds a `localStorage`/`sessionStorage` mock, fixing a **pre-existing** `localStorage.getItem is not a function` failure in `api/client.test.ts` (this branch doesn't touch the client; the suite was already red).

## Verification (all green locally)
- `npm run type-check` ✅  `npm run lint` (`--max-warnings 0`) ✅  `npm run build` ✅
- `npm run test:ci` ✅ — 12 tests pass, incl. the previously-red `api/client.test.ts`.

## Notes
- Accent is `#5b50e6`. The page background is a deliberate, very faint (~7%) purple radial wash to make white "not plain" — an intentional product choice for this app, not the generic "avoid gradients" default.
- Design mockups live in `dashboard-mockups/` (gitignored — not in this PR).
